### PR TITLE
Moving extension to be in line with the symfony standards

### DIFF
--- a/src/DependencyInjection/UecodeQPushExtension.php
+++ b/src/DependencyInjection/UecodeQPushExtension.php
@@ -31,11 +31,11 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 
 /**
- * QPushCustomExtension
+ * UecodeQPushExtension
  *
  * @author Keith Kirk <kkirk@undergroundelephant.com>
  */
-class QPushCustomExtension extends Extension
+class UecodeQPushExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/src/UecodeQPushBundle.php
+++ b/src/UecodeQPushBundle.php
@@ -24,11 +24,9 @@ namespace Uecode\Bundle\QPushBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-
-use Uecode\Bundle\QPushBundle\DependencyInjection\QPushCustomExtension;
-use Uecode\Bundle\QPushBundle\DependencyInjection\Compiler\QPushCompilerPass;
-
 use Symfony\Component\HttpKernel\DependencyInjection\RegisterListenersPass;
+use Uecode\Bundle\QPushBundle\DependencyInjection\Compiler\QPushCompilerPass;
+use Uecode\Bundle\QPushBundle\DependencyInjection\UecodeQPushExtension;
 
 /**
  * UecodeQPushBundle
@@ -38,6 +36,15 @@ use Symfony\Component\HttpKernel\DependencyInjection\RegisterListenersPass;
 class UecodeQPushBundle extends Bundle
 {
     /**
+     * {@inlineDoc}
+     */
+    public function __construct()
+    {
+        // Setting extension to bypass alias convention check
+        $this->extension = new UecodeQPushExtension();
+    }
+
+    /**
      * Adds the Compiler Passes for the QPushBundle
      *
      * @param ContainerBuilder $container
@@ -45,8 +52,6 @@ class UecodeQPushBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
-
-        $container->registerExtension(new QPushCustomExtension);
 
         $container->addCompilerPass(new QPushCompilerPass);
         $container->addCompilerPass(


### PR DESCRIPTION
The extension naming should follow the [docs](http://symfony.com/doc/current/cookbook/bundles/extension.html#creating-an-extension-class)

> If you do choose to expose a semantic configuration for your bundle, you'll first need to create a new "Extension" class, which will handle the process. This class should live in the DependencyInjection directory of your bundle and its name should be constructed by replacing the Bundle suffix of the Bundle class name with Extension. For example, the Extension class of AcmeHelloBundle would be called AcmeHelloExtension
