### PR TITLE
removed unnecessary route parameter

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -28,7 +28,6 @@ services:
         arguments:
             - @event_dispatcher
             - @uecode_qpush.logger
-            - %uecode_qpush.route%
         tags:
             - { name: kernel.event_listener, event: kernel.request, priority: 254 }
 


### PR DESCRIPTION
Fixes non-existant parameter in services.yml.  Fixes #29. Was commited unintentionally [here](https://github.com/kmfk/qpush-bundle/commit/8102857bf8208e5262f7346df323c9ce86e8dd0e#diff-24d25eb5e07008bbf94172e9c1049950R31)

I'll update unit tests a little bit later to avoid this sort of thing in the future.
