### PR TITLE
IronMqProvider no message bug fixed

### DIFF
--- a/src/Provider/IronMqProvider.php
+++ b/src/Provider/IronMqProvider.php
@@ -183,7 +183,7 @@ class IronMqProvider extends AbstractProvider
             $this->options['message_timeout']
         );
         
-        if (!$messages) {
+        if (!is_array($messages)) {
             $this->log(200, "No messages found in queue.");
             
             return [];


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

IronMq client returns a null value when no messages found in queue therefore the following foreach loop throws an invalid argument error.

Here you can see the line at which it returns a null value: 
https://github.com/iron-io/iron_mq_php/blob/master/IronMQ.class.php#L334
