### PR TITLE
Fixed publish in AWSProvider

### DIFF
--- a/src/Provider/AwsProvider.php
+++ b/src/Provider/AwsProvider.php
@@ -175,7 +175,7 @@ class AwsProvider extends AbstractProvider
 
         if ($options['push_notifications']) {
 
-            if ($this->topicExists()) {
+            if (!$this->topicExists()) {
                 $this->create();
             }
 


### PR DESCRIPTION
As much as I can see, this was an error causing the publishing to break if you cleared the app cache.
