### PR TITLE
Reverts #54

### DIFF
--- a/src/Command/QueueReceiveCommand.php
+++ b/src/Command/QueueReceiveCommand.php
@@ -76,19 +76,16 @@ class QueueReceiveCommand extends ContainerAwareCommand
             );
         }
 
-        $provider   = $registry->get($name);
-        $messages   = $provider->receive();
-        $count      = sizeof($messages);
+        $dispatcher = $this->getContainer()->get('event_dispatcher');
+        $messages   = $registry->get($name)->receive();
+
         foreach ($messages as $message) {
-
-            $messageEvent   = new MessageEvent($name, $message);
-            $dispatcher     = $this->getContainer()->get('event_dispatcher');
-
+            $messageEvent = new MessageEvent($name, $message);
             $dispatcher->dispatch(Events::Message($name), $messageEvent);
         }
 
         $msg = "<info>Finished polling %s Queue, %d messages fetched.</info>";
-        $this->output->writeln(sprintf($msg, $name, $count));
+        $this->output->writeln(sprintf($msg, $name, sizeof($messages)));
 
         return 0;
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -54,8 +54,8 @@ class Configuration implements ConfigurationInterface
 
     private function getProvidersNode()
     {
-        $treeBuilder    = new TreeBuilder();
-        $node           = $treeBuilder->root('providers');
+        $treeBuilder = new TreeBuilder();
+        $node        = $treeBuilder->root('providers');
 
         $node
             ->children()
@@ -97,8 +97,8 @@ class Configuration implements ConfigurationInterface
 
     private function getQueuesNode()
     {
-        $treeBuilder    = new TreeBuilder();
-        $node           = $treeBuilder->root('queues');
+        $treeBuilder = new TreeBuilder();
+        $node        = $treeBuilder->root('queues');
 
         $node
             ->requiresAtLeastOneElement()
@@ -161,8 +161,8 @@ class Configuration implements ConfigurationInterface
 
     private function getSubscribersNode()
     {
-        $treeBuilder    = new TreeBuilder();
-        $node           = $treeBuilder->root('subscribers');
+        $treeBuilder = new TreeBuilder();
+        $node        = $treeBuilder->root('subscribers');
 
         $node
             ->prototype('array')

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -87,15 +87,17 @@ class RequestListener
 
         // We add the message in an array with Queue as the property name
         $message    = json_decode($event->getRequest()->getContent(), true);
-        $queue      = key($message);
+        $queue      = $message['_qpush_queue'];
         $metadata   = [
-            'iron-subscriber-message-id'    => $headers->get('iron-subscriber-message-id'),
-            'iron-subscriber-message-url'   => $headers->get('iron-subscriber-message-url')
+            'iron-subscriber-message-id'  => $headers->get('iron-subscriber-message-id'),
+            'iron-subscriber-message-url' => $headers->get('iron-subscriber-message-url')
         ];
+
+        unset($message['_qpush_queue']);
 
         $notification = new Notification(
             $messageId,
-            $message[$queue],
+            $message,
             $metadata
         );
 

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -87,6 +87,11 @@ class RequestListener
 
         // We add the message in an array with Queue as the property name
         $message    = json_decode($event->getRequest()->getContent(), true);
+
+        if (empty($message['_qpush_queue'])) {
+            return;
+        }
+
         $queue      = $message['_qpush_queue'];
         $metadata   = [
             'iron-subscriber-message-id'  => $headers->get('iron-subscriber-message-id'),

--- a/src/Provider/IronMqProvider.php
+++ b/src/Provider/IronMqProvider.php
@@ -140,7 +140,7 @@ class IronMqProvider extends AbstractProvider
 
         $result = $this->ironmq->postMessage(
             $this->getNameWithPrefix(),
-            json_encode([$this->name => $message]),
+            json_encode($message + ['_qpush_queue' => $this->name]),
             [
                 'timeout'       => $options['message_timeout'],
                 'delay'         => $options['message_delay'],
@@ -183,14 +183,16 @@ class IronMqProvider extends AbstractProvider
         // Convert to Message Class
         foreach ($messages as &$message) {
             $id         = $message->id;
-            $body       = $message->body;
+            $body       = json_decode($message->body, true);
             $metadata   = [
                 'timeout'           => $message->timeout,
                 'reserved_count'    => $message->reserved_count,
                 'push_status'       => $message->push_status
             ];
 
-            $message = new Message($id, $body, $metadata);
+            unset($body['_qpush_queue']);
+
+            $message = new Message($id, json_encode($body), $metadata);
 
             $this->log(200, "Message has been received.", ['message_id' => $id]);
         }

--- a/src/Provider/IronMqProvider.php
+++ b/src/Provider/IronMqProvider.php
@@ -140,7 +140,7 @@ class IronMqProvider extends AbstractProvider
 
         $result = $this->ironmq->postMessage(
             $this->getNameWithPrefix(),
-            json_encode($message),
+            json_encode([$this->name => $message]),
             [
                 'timeout'       => $options['message_timeout'],
                 'delay'         => $options['message_delay'],

--- a/tests/EventListener/RequestListenerTest.php
+++ b/tests/EventListener/RequestListenerTest.php
@@ -111,7 +111,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
             'TopicArn'  => 'SomeArn',
             'Subject'   => 'aws-test',
             'Message'   => '{"foo": "bar"}',
-            'Timestamp' => date('Y-m-d H:i:s')
+            'Timestamp' => date('Y-m-d H:i:s', 1422040603)
         ];
 
         $request = new Request([],[],[],[],[],[], json_encode($message));
@@ -127,8 +127,24 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
 
     public function AwsOnNotificationReceived(NotificationEvent $event)
     {
-        $this->assertEquals($event->getNotification()->getId(), 123);
-        $this->assertEquals($event->getNotification()->getBody(), ['foo' => 'bar']);
+        $notification = $event->getNotification();
+        $this->assertInstanceOf('\Uecode\Bundle\QPushBundle\Message\Notification', $notification);
+
+        $this->assertEquals(123, $notification->getId());
+
+        $this->assertInternalType('array', $notification->getBody());
+        $this->assertEquals($notification->getBody(), ['foo' => 'bar']);
+
+        $this->assertInstanceOf('\Doctrine\Common\Collections\ArrayCollection', $notification->getMetadata());
+        $this->assertEquals(
+            [
+                'Type'      => 'Notification',
+                'TopicArn'  => 'SomeArn',
+                'Timestamp' => date('Y-m-d H:i:s', 1422040603),
+                'Subject'   => 'aws-test'
+            ],
+            $notification->getMetadata()->toArray()
+        );
     }
 
     public function testListenerHandlesAwsSubscriptionRequests()
@@ -141,7 +157,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
             'SubscribeUrl' => 'http://foo.bar',
             'Subject'      => 'aws-test',
             'Message'      => '{"foo": "bar"}',
-            'Timestamp'    => date('Y-m-d H:i:s')
+            'Timestamp'    => date('Y-m-d H:i:s', 1422040603)
         ];
 
         $request = new Request([],[],[],[],[],[], json_encode($message));

--- a/tests/MockClient/IronMqMockClient.php
+++ b/tests/MockClient/IronMqMockClient.php
@@ -64,7 +64,7 @@ class IronMqMockClient
     {
         $response       = new \stdClass;
         $response->id   = 123;
-        $response->ids  = [ 123 ];
+        $response->ids  = [123];
         $response->msg  = "Messages put on queue.";
 
         return $response;
@@ -74,7 +74,7 @@ class IronMqMockClient
     {
         $response                   = new \stdClass;
         $response->id               = 123;
-        $response->body             = '{"test":{"foo":"bar"}}';
+        $response->body             = '{"foo":"bar","_qpush_queue":"test"}';
         $response->timeout          = 60;
         $response->reserved_count   = 1;
         $response->push_status      = new \stdClass;

--- a/tests/Provider/IronMqProviderTest.php
+++ b/tests/Provider/IronMqProviderTest.php
@@ -152,7 +152,9 @@ class IronMqProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testReceive()
     {
-        $this->assertTrue(is_array($this->provider->receive()));
+        $messages = $this->provider->receive();
+        $this->assertInternalType('array', $messages);
+        $this->assertEquals(['foo' => 'bar'], $messages[0]->getBody());
     }
 
     public function testDelete()
@@ -177,6 +179,7 @@ class IronMqProviderTest extends \PHPUnit_Framework_TestCase
             NotificationEvent::TYPE_MESSAGE,
             new Notification(123, "test", [])
         );
+
         $event->setDispatcher(
             $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface')
         );


### PR DESCRIPTION
- fixes an issue introduced in #54 - the queue name must be included in all Iron MQ messages as a way to properly dispatch events
- moved the Iron MQ queue name to a `_qpush_queue` property on published messages 
  * while this property is still removed by qpush directly, this change makes it a little more discrete when qpush publishes the messages that are read by other clients
- updated tests to check that the queue name is removed automatically from messages sent and received by this qpush