### PR TITLE
Remove Symfony framework dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/dependency-injection": "^2.6",
         "symfony/config": "^2.6",
         "symfony/http-kernel": "^2.6",
-        "symfony/console": "2.8.*",
+        "symfony/console": "2.7.*",
         "symfony/monolog-bundle":   "~2.6"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,11 @@
     "require": {
         "php":                      ">=5.4.0",
         "doctrine/common":          "~2.4",
-        "symfony/framework-bundle": "~2.3",
-        "symfony/monolog-bundle":   "~2.3"
+        "symfony/dependency-injection": "^2.6",
+        "symfony/config": "^2.6",
+        "symfony/http-kernel": "^2.6",
+        "symfony/console": "3.0.*@dev",
+        "symfony/monolog-bundle":   "~2.6"
     },
     "require-dev": {
         "phpunit/phpunit":        "~3.7",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/dependency-injection": "^2.6",
         "symfony/config": "^2.6",
         "symfony/http-kernel": "^2.6",
-        "symfony/console": "3.0.*@dev",
+        "symfony/console": "2.8.*",
         "symfony/monolog-bundle":   "~2.6"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     "require": {
         "php":                      ">=5.4.0",
         "doctrine/common":          "~2.4",
-        "symfony/dependency-injection": "^2.6",
-        "symfony/config": "^2.6",
-        "symfony/http-kernel": "^2.6",
-        "symfony/console": "2.7.*",
-        "symfony/monolog-bundle":   "~2.6"
+        "symfony/dependency-injection": "~2.3, <3.0.0@dev",
+        "symfony/config": "~2.3, <3.0.0@dev",
+        "symfony/http-kernel": "~2.3, <3.0.0@dev",
+        "symfony/console": "~2.3, <3.0.0@dev",
+        "symfony/monolog-bundle":   "~2.3, <3.0.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit":        "~3.7",

--- a/src/Command/QueueBuildCommand.php
+++ b/src/Command/QueueBuildCommand.php
@@ -22,16 +22,20 @@
 
 namespace Uecode\Bundle\QPushBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @author Keith Kirk <kkirk@undergroundelephant.com>
  */
-class QueueBuildCommand extends ContainerAwareCommand
+class QueueBuildCommand extends Command implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     protected $output;
 
     protected function configure()
@@ -51,7 +55,7 @@ class QueueBuildCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->output = $output;
-        $registry = $this->getContainer()->get('uecode_qpush');
+        $registry = $this->container->get('uecode_qpush');
 
         $name = $input->getArgument('name');
 

--- a/src/Command/QueueBuildCommand.php
+++ b/src/Command/QueueBuildCommand.php
@@ -27,14 +27,31 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Keith Kirk <kkirk@undergroundelephant.com>
  */
 class QueueBuildCommand extends Command implements ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @var ContainerInterface
+     *
+     * @api
+     */
+    protected $container;
+
+    /**
+     * Sets the Container associated with this Controller.
+     *
+     * @param ContainerInterface $container A ContainerInterface instance
+     *
+     * @api
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
 
     protected $output;
 

--- a/src/Command/QueueDestroyCommand.php
+++ b/src/Command/QueueDestroyCommand.php
@@ -28,14 +28,31 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Keith Kirk <kkirk@undergroundelephant.com>
  */
 class QueueDestroyCommand extends Command implements ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @var ContainerInterface
+     *
+     * @api
+     */
+    protected $container;
+
+    /**
+     * Sets the Container associated with this Controller.
+     *
+     * @param ContainerInterface $container A ContainerInterface instance
+     *
+     * @api
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
 
     protected $output;
 

--- a/src/Command/QueueDestroyCommand.php
+++ b/src/Command/QueueDestroyCommand.php
@@ -22,17 +22,21 @@
 
 namespace Uecode\Bundle\QPushBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @author Keith Kirk <kkirk@undergroundelephant.com>
  */
-class QueueDestroyCommand extends ContainerAwareCommand
+class QueueDestroyCommand extends Command implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     protected $output;
 
     protected function configure()
@@ -58,7 +62,7 @@ class QueueDestroyCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->output = $output;
-        $registry = $this->getContainer()->get('uecode_qpush');
+        $registry = $this->container->get('uecode_qpush');
         $dialog = $this->getHelperSet()->get('dialog');
 
         $name = $input->getArgument('name');

--- a/src/Command/QueuePublishCommand.php
+++ b/src/Command/QueuePublishCommand.php
@@ -27,14 +27,31 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Keith Kirk <kkirk@undergroundelephant.com>
  */
 class QueuePublishCommand extends Command implements ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @var ContainerInterface
+     *
+     * @api
+     */
+    protected $container;
+
+    /**
+     * Sets the Container associated with this Controller.
+     *
+     * @param ContainerInterface $container A ContainerInterface instance
+     *
+     * @api
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
 
     protected $output;
 

--- a/src/Command/QueuePublishCommand.php
+++ b/src/Command/QueuePublishCommand.php
@@ -22,16 +22,20 @@
 
 namespace Uecode\Bundle\QPushBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @author Keith Kirk <kkirk@undergroundelephant.com>
  */
-class QueuePublishCommand extends ContainerAwareCommand
+class QueuePublishCommand extends Command implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     protected $output;
 
     protected function configure()
@@ -55,7 +59,7 @@ class QueuePublishCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->output = $output;
-        $registry = $this->getContainer()->get('uecode_qpush');
+        $registry = $this->container->get('uecode_qpush');
 
         $name = $input->getArgument('name');
         $message = $input->getArgument('message');

--- a/src/Command/QueueReceiveCommand.php
+++ b/src/Command/QueueReceiveCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Uecode\Bundle\QPushBundle\Event\Events;
 use Uecode\Bundle\QPushBundle\Event\MessageEvent;
 
@@ -36,7 +36,24 @@ use Uecode\Bundle\QPushBundle\Event\MessageEvent;
  */
 class QueueReceiveCommand extends Command implements ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @var ContainerInterface
+     *
+     * @api
+     */
+    protected $container;
+
+    /**
+     * Sets the Container associated with this Controller.
+     *
+     * @param ContainerInterface $container A ContainerInterface instance
+     *
+     * @api
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
 
     protected $output;
 

--- a/src/Command/QueueReceiveCommand.php
+++ b/src/Command/QueueReceiveCommand.php
@@ -22,18 +22,22 @@
 
 namespace Uecode\Bundle\QPushBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Uecode\Bundle\QPushBundle\Event\Events;
 use Uecode\Bundle\QPushBundle\Event\MessageEvent;
 
 /**
  * @author Keith Kirk <kkirk@undergroundelephant.com>
  */
-class QueueReceiveCommand extends ContainerAwareCommand
+class QueueReceiveCommand extends Command implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     protected $output;
 
     protected function configure()
@@ -53,7 +57,7 @@ class QueueReceiveCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->output = $output;
-        $registry = $this->getContainer()->get('uecode_qpush');
+        $registry = $this->container->get('uecode_qpush');
 
         $name = $input->getArgument('name');
 

--- a/src/DependencyInjection/UecodeQPushExtension.php
+++ b/src/DependencyInjection/UecodeQPushExtension.php
@@ -139,8 +139,7 @@ class UecodeQPushExtension extends Extension
             }
 
             $aws = new Definition('Aws\Common\Aws');
-            $aws->setFactoryClass('Aws\Common\Aws');
-            $aws->setFactoryMethod('factory');
+            $aws->setFactory(['Aws\Common\Aws', 'factory']);
             $aws->setArguments([
                 [
                     'key'      => $config['key'],

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -79,6 +79,7 @@ class RequestListener
      * Handles Messages sent from a IronMQ Push Queue
      *
      * @param GetResponseEvent $event The Kernel Request's GetResponseEvent
+     * @return string|void
      */
     private function handleIronMqNotifications(GetResponseEvent $event)
     {
@@ -118,6 +119,7 @@ class RequestListener
      * Handles Notifications sent from AWS SNS
      *
      * @param GetResponseEvent $event The Kernel Request's GetResponseEvent
+     * @return string
      */
     private function handleSnsNotifications(GetResponseEvent $event)
     {

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -24,6 +24,7 @@ namespace Uecode\Bundle\QPushBundle\Provider;
 
 use Doctrine\Common\Cache\Cache;
 use Symfony\Bridge\Monolog\Logger;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Uecode\Bundle\QPushBundle\Provider\ProviderInterface;
 use Uecode\Bundle\QPushBundle\Event\MessageEvent;
 use Uecode\Bundle\QPushBundle\Event\NotificationEvent;
@@ -121,14 +122,18 @@ abstract class AbstractProvider implements ProviderInterface
     }
 
     /**
+     * @param NotificationEvent $event
+     * @param string $eventName Name of the event
+     * @param EventDispatcherInterface $dispatcher
      * @return bool
      */
-    public function onNotification(NotificationEvent $event)
+    public function onNotification(NotificationEvent $event, $eventName, EventDispatcherInterface $dispatcher)
     {
         return false;
     }
 
     /**
+     * @param MessageEvent $event
      * @return bool
      */
     public function onMessageReceived(MessageEvent $event)

--- a/src/Provider/IronMqProvider.php
+++ b/src/Provider/IronMqProvider.php
@@ -25,6 +25,7 @@ namespace Uecode\Bundle\QPushBundle\Provider;
 use IronMQ;
 use Doctrine\Common\Cache\Cache;
 use Symfony\Bridge\Monolog\Logger;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Uecode\Bundle\QPushBundle\Event\Events;
 use Uecode\Bundle\QPushBundle\Event\MessageEvent;
 use Uecode\Bundle\QPushBundle\Event\NotificationEvent;
@@ -252,8 +253,11 @@ class IronMqProvider extends AbstractProvider
      * Dispatches the `{queue}.message_received` event
      *
      * @param NotificationEvent $event The Notification Event
+     * @param string $eventName Name of the event
+     * @param EventDispatcherInterface $dispatcher
+     * @return void
      */
-    public function onNotification(NotificationEvent $event)
+    public function onNotification(NotificationEvent $event, $eventName, EventDispatcherInterface $dispatcher)
     {
         $message = new Message(
             $event->getNotification()->getId(),
@@ -269,7 +273,7 @@ class IronMqProvider extends AbstractProvider
 
         $messageEvent = new MessageEvent($this->name, $message);
 
-        $event->getDispatcher()->dispatch(
+        $dispatcher->dispatch(
             Events::Message($this->name),
             $messageEvent
         );
@@ -284,6 +288,7 @@ class IronMqProvider extends AbstractProvider
      * Stops Event Propagation after removing the Message
      *
      * @param MessageEvent $event The SQS Message Event
+     * @return void
      */
     public function onMessageReceived(MessageEvent $event)
     {

--- a/src/UecodeQPushBundle.php
+++ b/src/UecodeQPushBundle.php
@@ -22,10 +22,9 @@
 
 namespace Uecode\Bundle\QPushBundle;
 
+use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\DependencyInjection\RegisterListenersPass;
-use Uecode\Bundle\QPushBundle\DependencyInjection\Compiler\QPushCompilerPass;
 use Uecode\Bundle\QPushBundle\DependencyInjection\UecodeQPushExtension;
 
 /**

--- a/tests/Provider/AbstractProviderTest.php
+++ b/tests/Provider/AbstractProviderTest.php
@@ -149,11 +149,12 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testOnNotification()
     {
+        $dispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $result = $this->provider->onNotification(new NotificationEvent(
             'test',
             NotificationEvent::TYPE_SUBSCRIPTION,
             new Notification(123, "test", [])
-        ));
+        ), NotificationEvent::TYPE_SUBSCRIPTION, $dispatcher);
 
         $this->assertFalse($result);
     }

--- a/tests/Provider/AwsProviderTest.php
+++ b/tests/Provider/AwsProviderTest.php
@@ -263,11 +263,13 @@ class AwsProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testOnNotificationSubscriptionEvent()
     {
+        $dispatcher = $this->getMockForAbstractClass('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $this->provider->onNotification(new NotificationEvent(
             'test',
             NotificationEvent::TYPE_SUBSCRIPTION,
             new Notification(123, "test", [])
-        ));
+        ), NotificationEvent::TYPE_SUBSCRIPTION, $dispatcher);
+
     }
 
     public function testOnNotificationMessageEvent()
@@ -277,11 +279,12 @@ class AwsProviderTest extends \PHPUnit_Framework_TestCase
             NotificationEvent::TYPE_MESSAGE,
             new Notification(123, "test", [])
         );
-        $event->setDispatcher(
+
+        $this->provider->onNotification(
+            $event,
+            NotificationEvent::TYPE_MESSAGE,
             $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface')
         );
-
-        $this->provider->onNotification($event);
     }
 
     public function testOnMessageReceived()

--- a/tests/Provider/IronMqProviderTest.php
+++ b/tests/Provider/IronMqProviderTest.php
@@ -181,11 +181,11 @@ class IronMqProviderTest extends \PHPUnit_Framework_TestCase
             new Notification(123, "test", [])
         );
 
-        $event->setDispatcher(
+        $this->provider->onNotification(
+            $event,
+            NotificationEvent::TYPE_MESSAGE,
             $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface')
         );
-
-        $this->provider->onNotification($event);
     }
 
     public function testOnMessageReceived()


### PR DESCRIPTION
This should be a new major version with backward compatible break but it allow the bundle to be use in console application, where including symfony/framework-bundle is an overkill.