### PR TITLE
Feature/add iam support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ uecode_qpush:
                     - { endpoint: http://example.com/qpush, protocol: http }
 ```
 
+You may exclude aws key and secret to default to IAM role on the EC2 machine.
+
 ##Publishing messages to your Queue
 
 Publishing messages is simple - fetch the registered Provider service from the

--- a/docs/aws-provider.rst
+++ b/docs/aws-provider.rst
@@ -41,6 +41,7 @@ credentials in your configuration.
                     subscribers:
                         - { endpoint: http://example.com/qpush, protocol: http }
 
+You may exclude the aws key and secret if you are using IAM role in EC2.
 
 Using SNS
 ^^^^^^^^^

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -57,7 +57,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder    = new TreeBuilder();
         $node           = $treeBuilder->root('providers');
         $requirements   = [
-            'aws' => ['key', 'secret'],
+            'aws' => [],
             'ironmq' => ['token', 'project_id'],
             'sync' => [],
             'custom' => ['service'],

--- a/src/DependencyInjection/UecodeQPushExtension.php
+++ b/src/DependencyInjection/UecodeQPushExtension.php
@@ -142,15 +142,17 @@ class UecodeQPushExtension extends Extension
                 );
             }
 
+            $awsConfig = [];
+            if (!empty($config['key']) && !empty($config['secret'])) {
+                $awsConfig['key'] = $config['key'];
+                $awsConfig['secret'] = $config['secret'];
+            }
+
+            $awsConfig['region'] = $config['region'];
+
             $aws = new Definition('Aws\Common\Aws');
             $aws->setFactory(['Aws\Common\Aws', 'factory']);
-            $aws->setArguments([
-                [
-                    'key'      => $config['key'],
-                    'secret'   => $config['secret'],
-                    'region'   => $config['region']
-                ]
-            ]);
+            $aws->setArguments([$awsConfig]);
 
             $container->setDefinition($service, $aws)
                 ->setPublic(false);


### PR DESCRIPTION
Make aws key and secret optional for SQS, allow PHP SDK to use IAM role on EC2