### PR TITLE
Iron mq 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
             "email":    "kkirk@undergroundelephant.com",
             "role":     "developer",
             "homepage": "http://undergroundelephant.com"
-        },
+        }
     ],
     "support": {
         "email": "kkirk@undergroundelephant.com"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
             "email":    "kkirk@undergroundelephant.com",
             "role":     "developer",
             "homepage": "http://undergroundelephant.com"
-        }
+        },
     ],
     "support": {
         "email": "kkirk@undergroundelephant.com"
@@ -28,7 +28,7 @@
     "require-dev": {
         "phpunit/phpunit":        "~3.7",
         "aws/aws-sdk-php":        "~2.5",
-        "iron-io/iron_mq":        "~1.5",
+        "iron-io/iron_mq":        "~2.0",
         "symfony/finder":         "~2.3",
         "symfony/filesystem":     "~2.3"
     },

--- a/src/DependencyInjection/UecodeQPushExtension.php
+++ b/src/DependencyInjection/UecodeQPushExtension.php
@@ -174,13 +174,13 @@ class UecodeQPushExtension extends Extension
 
         if (!$container->hasDefinition($service)) {
 
-            if (!class_exists('IronMQ')) {
+            if (!class_exists('IronMQ\IronMQ')) {
                 throw new \RuntimeException(
                     'You must require "iron-io/iron_mq" to use the Iron MQ provider.'
                 );
             }
 
-            $ironmq = new Definition('IronMQ');
+            $ironmq = new Definition('IronMQ\IronMQ');
             $ironmq->setArguments([
                 [
                     'token'         => $config['token'],


### PR DESCRIPTION
This request updates the dependency for Iron-io/iron_mq package to ~2.0
The DI container was updated to reflect the new class name associated with the package update.