### PR TITLE
Added support for AWS SDK v3 (v2 still supported) + fixed php error in uecode:qpush:receive command

### DIFF
--- a/src/Command/QueueReceiveCommand.php
+++ b/src/Command/QueueReceiveCommand.php
@@ -97,7 +97,7 @@ class QueueReceiveCommand extends Command implements ContainerAwareInterface
             );
         }
 
-        $dispatcher = $this->getContainer()->get('event_dispatcher');
+        $dispatcher = $this->container->get('event_dispatcher');
         $messages   = $registry->get($name)->receive();
 
         foreach ($messages as $message) {

--- a/src/DependencyInjection/UecodeQPushExtension.php
+++ b/src/DependencyInjection/UecodeQPushExtension.php
@@ -136,20 +136,35 @@ class UecodeQPushExtension extends Extension
 
         if (!$container->hasDefinition($service)) {
 
-            if (!class_exists('Aws\Common\Aws')) {
+            $aws2 = class_exists('Aws\Common\Aws');
+            $aws3 = class_exists('Aws\Sdk');
+            if (!$aws2 && !$aws3) {
                 throw new \RuntimeException(
                     'You must require "aws/aws-sdk-php" to use the AWS provider.'
                 );
             }
-
-            $aws = new Definition('Aws\Common\Aws');
-            $aws->setFactory(['Aws\Common\Aws', 'factory']);
-            $aws->setArguments([
-                [
+            if ($aws2) {
+                $aws = new Definition('Aws\Common\Aws');
+                $aws->setFactory(['Aws\Common\Aws', 'factory']);
+                $args =  [
                     'key'      => $config['key'],
                     'secret'   => $config['secret'],
                     'region'   => $config['region']
-                ]
+                ];
+            } else {
+                $aws = new Definition('Aws\Sdk');
+                //$aws->setFactory(['Aws\AwsClient', 'factory']);
+                $args =  [
+                    'credentials'   => [
+                        'key'      => $config['key'],
+                        'secret'   => $config['secret']
+                    ],
+                    'region'   => $config['region'],
+                    'version'  => 'latest'
+                ];
+            }
+            $aws->setArguments([
+                $args
             ]);
 
             $container->setDefinition($service, $aws)

--- a/src/Provider/AwsProvider.php
+++ b/src/Provider/AwsProvider.php
@@ -75,8 +75,8 @@ class AwsProvider extends AbstractProvider
         $this->logger   = $logger;
         // get() method used for sdk v2, create methods for v3
         $useGet = method_exists($client, 'get');
-        $this->sqs      = $useGet ? $client->get('sqs') : $client->createSqs();
-        $this->sns      = $useGet ? $client->get('sns') : $client->createSns();
+        $this->sqs      = $useGet ? $client->get('Sqs') : $client->createSqs();
+        $this->sns      = $useGet ? $client->get('Sns') : $client->createSns();
     }
 
     public function getProvider()

--- a/src/Provider/AwsProvider.php
+++ b/src/Provider/AwsProvider.php
@@ -75,8 +75,8 @@ class AwsProvider extends AbstractProvider
         $this->logger   = $logger;
         // get() method used for sdk v2, create methods for v3
         $useGet = method_exists($client, 'get');
-        $this->sqs      = $useGet ? $this->get('sqs') : $client->createSqs();
-        $this->sns      = $useGet ? $this->get('sns') : $client->createSns();
+        $this->sqs      = $useGet ? $client->get('sqs') : $client->createSqs();
+        $this->sns      = $useGet ? $client->get('sns') : $client->createSns();
     }
 
     public function getProvider()

--- a/src/Provider/AwsProvider.php
+++ b/src/Provider/AwsProvider.php
@@ -22,10 +22,10 @@
 
 namespace Uecode\Bundle\QPushBundle\Provider;
 
-use Aws\Common\Aws;
 use Aws\Sns\SnsClient;
 use Aws\Sqs\SqsClient;
 use Aws\Sqs\Exception\SqsException;
+
 use Doctrine\Common\Cache\Cache;
 use Symfony\Bridge\Monolog\Logger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -71,10 +71,12 @@ class AwsProvider extends AbstractProvider
     {
         $this->name     = $name;
         $this->options  = $options;
-        $this->sqs      = $client->get('Sqs');
-        $this->sns      = $client->get('Sns');
         $this->cache    = $cache;
         $this->logger   = $logger;
+        // get() method used for sdk v2, create methods for v3
+        $useGet = method_exists($client, 'get');
+        $this->sqs      = $useGet ? $this->get('sqs') : $client->createSqs();
+        $this->sns      = $useGet ? $this->get('sns') : $client->createSns();
     }
 
     public function getProvider()


### PR DESCRIPTION
- this library now also supports v3 of the aws sdk (while keeping support for v2).
- fixed the QueueReceiveCommand::getContainer() undefined method error.