### PR TITLE
improve Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,32 +4,41 @@ sudo: false
 
 cache:
     directories:
-        - $HOME/.composer/cache
+        - $HOME/.composer/cache/files
 
 php:
     - 5.4
     - 5.5
-    - 5.6
     - hhvm
     
 matrix:
+    fast_finish: true
+    include:
+        - php: 5.6
+          env: SYMFONY_VERSION=2.3.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.6.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.7.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.8.*
+        - php: 7.0
+          env: COVERAGE=yes
     allow_failures:
         - php: hhvm
 
-env:
-    - SYMFONY_VERSION=2.3.*
-    - SYMFONY_VERSION=2.4.*
-    - SYMFONY_VERSION=2.5.*
-    - SYMFONY_VERSION=2.6.*
-
-install:
+before_install:
+    - if [ "$COVERAGE" != "yes" -a "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
     - composer self-update
     - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
+    
+install:
     - composer install --prefer-dist
 
-script: phpunit --coverage-text --coverage-clover=coverage.clover
+script:
+    - if [ "$COVERAGE" = "yes" ]; then phpunit --coverage-text --coverage-clover=coverage.clover; else phpunit; fi
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - if [ "$COVERAGE" = "yes" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ "$COVERAGE" = "yes" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
 before_install:
     - if [ "$COVERAGE" != "yes" -a "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
     - composer self-update
-    - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
+    - if [ "$SYOMFONY_VERSION" != "" ]; then composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update; fi
     
 install:
     - composer install --prefer-dist


### PR DESCRIPTION
* fix the Composer cache directory
* run jobs with different Symfony versions only on PHP 5.6
* drop jobs for Symfony versions that reached EOL
* add job for PHP 7
* run code coverage reports only on PHP 7
* disable Xdebug when code coverage reports won't be generated
* finish as soon as possible (when either a mandatory job failed or only
  jobs that are allowed to fail are running)