### PR TITLE
fix YAML syntax

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -15,7 +15,6 @@ services:
     uecode_qpush.request_listener:
         class: %uecode_qpush.request_listener.class%
         arguments:
-            - @event_dispatcher
+            - '@event_dispatcher'
         tags:
             - { name: kernel.event_listener, event: kernel.request, priority: 254 }
-


### PR DESCRIPTION
`@` characters at the beginning of an unquoted scalar are reserved in
YAML for future use.