### PR TITLE
Improvements for FileProvider

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -24,6 +24,7 @@ For specific instructions on how to configure each provider, please view their d
     aws-provider
     iron-mq-provider
     sync-provider
+    file-provider
     custom-provider
 
 Caching

--- a/docs/file-provider.rst
+++ b/docs/file-provider.rst
@@ -1,13 +1,13 @@
 File Provider
 -------------
 
-The file provider uses the filesystem to dispatches and resolves queued messages.
+The file provider uses the filesystem to dispatch and resolve queued messages.
 
 Configuration
 ^^^^^^^^^^^^^
 
 To designate a queue as file, set the ``driver`` of its provider to ``file``. You will
-need to a read-able and write-able path to store the messages.
+need to configure a readable and writable path to store the messages.
 
 .. code-block:: yaml
 

--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -43,10 +43,12 @@ class FileProvider extends AbstractProvider
         $fileName = microtime(false);
         $fileName = str_replace(' ', '', $fileName);
         $path = substr(hash('md5', $fileName), 0, 3);
-        if (!is_dir($this->queuePath.DIRECTORY_SEPARATOR.$path)) {
-            mkdir($this->queuePath.DIRECTORY_SEPARATOR.$path);
-        }
+
         $fs = new Filesystem();
+        if (!$fs->exists($this->queuePath.DIRECTORY_SEPARATOR.$path)) {
+            $fs->mkdir($this->queuePath.DIRECTORY_SEPARATOR.$path);
+        }
+
         $fs->dumpFile(
             $this->queuePath.DIRECTORY_SEPARATOR.$path.DIRECTORY_SEPARATOR.$fileName.'.json',
             json_encode($message)


### PR DESCRIPTION
Documentation for the FileProvider was not linked in the official documentation.

Secondly: using the file provider failed when not calling ``php app/console uecode:qpush:build`` before. Using the methods of the Filesystem class is more consistent with the remainder of the code of the FileProvider and also creates parent directories when they are missing.