### PR TITLE
Monolog: only require basic monolog instance

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -23,7 +23,7 @@
 namespace Uecode\Bundle\QPushBundle\Provider;
 
 use Doctrine\Common\Cache\Cache;
-use Symfony\Bridge\Monolog\Logger;
+use Monolog\Logger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Uecode\Bundle\QPushBundle\Event\MessageEvent;
 use Uecode\Bundle\QPushBundle\Event\NotificationEvent;

--- a/src/Provider/AwsProvider.php
+++ b/src/Provider/AwsProvider.php
@@ -28,7 +28,7 @@ use Aws\Sqs\Exception\SqsException;
 use Aws\Sqs\SqsClient;
 
 use Doctrine\Common\Cache\Cache;
-use Symfony\Bridge\Monolog\Logger;
+use Monolog\Logger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Uecode\Bundle\QPushBundle\Event\Events;
 use Uecode\Bundle\QPushBundle\Event\MessageEvent;

--- a/src/Provider/CustomProvider.php
+++ b/src/Provider/CustomProvider.php
@@ -23,7 +23,7 @@
 namespace Uecode\Bundle\QPushBundle\Provider;
 
 use Doctrine\Common\Cache\Cache;
-use Symfony\Bridge\Monolog\Logger;
+use Monolog\Logger;
 
 /**
  * @author Keith Kirk <kkirk@undergroundelephant.com>

--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -2,7 +2,7 @@
 namespace Uecode\Bundle\QPushBundle\Provider;
 
 use Doctrine\Common\Cache\Cache;
-use Symfony\Bridge\Monolog\Logger;
+use Monolog\Logger;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;

--- a/src/Provider/IronMqProvider.php
+++ b/src/Provider/IronMqProvider.php
@@ -24,7 +24,7 @@ namespace Uecode\Bundle\QPushBundle\Provider;
 
 use IronMQ\IronMQ;
 use Doctrine\Common\Cache\Cache;
-use Symfony\Bridge\Monolog\Logger;
+use Monolog\Logger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Uecode\Bundle\QPushBundle\Event\Events;
 use Uecode\Bundle\QPushBundle\Event\MessageEvent;

--- a/src/Provider/ProviderInterface.php
+++ b/src/Provider/ProviderInterface.php
@@ -23,7 +23,7 @@
 namespace Uecode\Bundle\QPushBundle\Provider;
 
 use Doctrine\Common\Cache\Cache;
-use Symfony\Bridge\Monolog\Logger;
+use Monolog\Logger;
 
 /**
  * @author Keith Kirk <kkirk@undergroundelephant.com>
@@ -42,7 +42,7 @@ interface ProviderInterface
      * @param array  $options An array of configuration options for the Queue
      * @param mixed  $client  A Queue Client for the provider
      * @param Cache  $cache   An instance of Doctrine\Common\Cache\Cache
-     * @param Logger $logger  An instance of Symfony\Bridge\Mongolog\Logger
+     * @param Logger $logger  An instance of Mongolog\Logger
      */
     public function __construct($name, array $options, $client, Cache $cache, Logger $logger);
 

--- a/src/Provider/SyncProvider.php
+++ b/src/Provider/SyncProvider.php
@@ -24,7 +24,7 @@ namespace Uecode\Bundle\QPushBundle\Provider;
 
 
 use Doctrine\Common\Cache\Cache;
-use Symfony\Bridge\Monolog\Logger;
+use Monolog\Logger;
 use Uecode\Bundle\QPushBundle\Event\Events;
 use Uecode\Bundle\QPushBundle\Event\MessageEvent;
 use Uecode\Bundle\QPushBundle\Message\Message;
@@ -75,4 +75,4 @@ class SyncProvider extends AbstractProvider
     public function delete($id) {}
 
     public function receive(array $options = []) {}
-} 
+}

--- a/tests/MockClient/CustomMockClient.php
+++ b/tests/MockClient/CustomMockClient.php
@@ -23,7 +23,7 @@
 namespace Uecode\Bundle\QPushBundle\Tests\MockClient;
 
 use Doctrine\Common\Cache\Cache;
-use Symfony\Bridge\Monolog\Logger;
+use Monolog\Logger;
 use Uecode\Bundle\QPushBundle\Provider\AbstractProvider;
 
 /**
@@ -40,7 +40,7 @@ class CustomMockClient extends AbstractProvider
      * @param array  $options An array of configuration options for the Queue
      * @param mixed  $client  A Queue Client for the provider
      * @param Cache  $cache   An instance of Doctrine\Common\Cache\Cache
-     * @param Logger $logger  An instance of Symfony\Bridge\Mongolog\Logger
+     * @param Logger $logger  An instance of Mongolog\Logger
      */
     public function __construct($name, array $options, $client, Cache $cache, Logger $logger)
     {

--- a/tests/Provider/CustomProviderTest.php
+++ b/tests/Provider/CustomProviderTest.php
@@ -14,7 +14,7 @@ class CustomProviderTest extends \PHPUnit_Framework_TestCase
     private $provider;
 
     /**
-     * @var \Symfony\Bridge\Monolog\Logger
+     * @var \Monolog\Logger
      */
     private $logger;
 
@@ -89,7 +89,7 @@ class CustomProviderTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->logger = $this->getMock(
-            'Symfony\Bridge\Monolog\Logger', [], ['qpush.test']
+            'Monolog\Logger', [], ['qpush.test']
         );
 
         $this->mock = new CustomMockClient('custom', $options, null, $cache, $this->logger);
@@ -103,4 +103,4 @@ class CustomProviderTest extends \PHPUnit_Framework_TestCase
             ->expects($this->never())
             ->method(new \PHPUnit_Framework_Constraint_IsAnything());
     }
-} 
+}

--- a/tests/Provider/SyncProviderTest.php
+++ b/tests/Provider/SyncProviderTest.php
@@ -19,7 +19,7 @@ class SyncProviderTest extends \PHPUnit_Framework_TestCase
     protected $dispatcher;
 
     /**
-     * @var \Symfony\Bridge\Monolog\Logger
+     * @var \Monolog\Logger
      */
     protected $logger;
 
@@ -104,7 +104,7 @@ class SyncProviderTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->logger = $this->getMock(
-            'Symfony\Bridge\Monolog\Logger', [], ['qpush.test']
+            'Monolog\Logger', [], ['qpush.test']
         );
 
         return new SyncProvider('test', $options, $this->dispatcher, $cache, $this->logger);
@@ -120,4 +120,4 @@ class SyncProviderTest extends \PHPUnit_Framework_TestCase
             ->expects($this->never())
             ->method(new \PHPUnit_Framework_Constraint_IsAnything());
     }
-} 
+}

--- a/tests/Provider/TestProvider.php
+++ b/tests/Provider/TestProvider.php
@@ -23,7 +23,7 @@
 namespace Uecode\Bundle\QPushBundle\Tests\Provider;
 
 use Doctrine\Common\Cache\Cache;
-use Symfony\Bridge\Monolog\Logger;
+use Monolog\Logger;
 
 use Uecode\Bundle\QPushBundle\Provider\AbstractProvider;
 use Uecode\Bundle\QPushBundle\Message\Message;


### PR DESCRIPTION
This allows usage of the library without necessarily using the ```symfony/monolog-bundle```/```symfony/monolog-bridge```. Like for instance in silex apps.

I left the dependency in the composer file the library still requires monolog to be available via symfony DI but this way the logger instance does not have to be the bridge instance but can be any Monolog instance.