### PR TITLE
Fix for topicExists function

### DIFF
--- a/src/Provider/AwsProvider.php
+++ b/src/Provider/AwsProvider.php
@@ -22,7 +22,7 @@
 
 namespace Uecode\Bundle\QPushBundle\Provider;
 
-use Aws\Sns\Exception\NotFoundException;
+use Aws\Sns\Exception\SnsException;
 use Aws\Sns\SnsClient;
 use Aws\Sqs\Exception\SqsException;
 use Aws\Sqs\SqsClient;
@@ -427,7 +427,7 @@ class AwsProvider extends AbstractProvider
                 $this->sns->getTopicAttributes([
                     'TopicArn' => $topicArn
                 ]);
-            } catch (NotFoundException $e) {
+            } catch (SnsException $e) {
                 return false;
             }
 

--- a/tests/Message/NotificationTest.php
+++ b/tests/Message/NotificationTest.php
@@ -39,9 +39,6 @@ class NotificationTest extends BaseMessageTest
         $this->message = null;
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error
-     */
     public function testConstructor()
     {
         $notification = new Notification(123, ['foo' => 'bar'], ['baz' => 'qux']);

--- a/tests/MockClient/SnsMockClient.php
+++ b/tests/MockClient/SnsMockClient.php
@@ -22,7 +22,7 @@
 
 namespace Uecode\Bundle\QPushBundle\Tests\MockClient;
 
-use Aws\Sns\Exception\NotFoundException;
+use Aws\Sns\Exception\SnsException;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
@@ -54,7 +54,7 @@ class SnsMockClient
     public function getTopicAttributes(array $args)
     {
         if ($args['TopicArn'] == null) {
-            throw new NotFoundException;
+            throw new SnsException;
         }
 
         return new ArrayCollection([


### PR DESCRIPTION
Fix for aws/sdk v3 since Aws\Sns\Exception\NotFoundException is no longer available.
In case i had publishing only to queue and then decided to use notifications code fails on creating topic.

Also removed not needed annotation NotificationTest function testConstructor.