### PR TITLE
Fix invalid SNS topic names with FIFO SQS queues

### DIFF
--- a/src/Provider/AwsProvider.php
+++ b/src/Provider/AwsProvider.php
@@ -508,13 +508,14 @@ class AwsProvider extends AbstractProvider
             return false;
         }
 
+        $name = str_replace('.', '-', $this->getNameWithPrefix());
         $result = $this->sns->createTopic([
-            'Name' => $this->getNameWithPrefix()
+            'Name' => $name
         ]);
 
         $this->topicArn = $result->get('TopicArn');
 
-        $key = $this->getNameWithPrefix() . '_arn';
+        $key = $name . '_arn';
         $this->cache->save($key, $this->topicArn);
 
         $this->log(200, "Created SNS Topic", ['TopicARN' => $this->topicArn]);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

The AWS SQS queue with the enabled FIFO option requires the suffix `.fifo` for the queue name. However, the SNS topic (for push notification) doesn't accept the points for the topic name.

This PR fix this bug.