### PR TITLE
Fix dependency version of symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.6.0",
         "doctrine/common": "~2.4",
         "symfony/dependency-injection": "~2.3|^3.0|^4.0",
-        "symfony/config": "~2.3|^3.0",
+        "symfony/config": "~2.3|^3.0|^4.0",
         "symfony/http-kernel": "~2.3|^3.0|^4.0",
         "symfony/console": "~2.3|^3.0|^4.0",
         "symfony/monolog-bundle": "~2.3|^3.0|^4.0"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Fix the invalid version of `symfony/config` dependency when the Symfony 4 is used.