### PR TITLE
Fix the service visibility for Symfony 4

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -4,6 +4,7 @@ services:
         class: Uecode\Bundle\QPushBundle\Provider\ProviderRegistry
     uecode_qpush:
         alias: uecode_qpush.registry
+        public: true
 
     ### QPush Default File Cache
     uecode_qpush.file_cache:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Fix the visibility of the `uecode_qpush` service with Symfony 4 Flex. This alias is used by the commands using the `$container->get()` method and require the public visibility otherwise this exception is thrown:

```
[Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]
The "uecode_qpush" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead. 
```